### PR TITLE
一个小 bug 以及细节改动

### DIFF
--- a/deskmark/app/app.jsx
+++ b/deskmark/app/app.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import DeskMark from 'components/desk-mark/desk-mark';
 
-import 'node_modules/bootstrap/scss/bootstrap.scss';
+import 'bootstrap/scss/bootstrap.scss';
 
 const app = document.createElement('div');
 document.body.appendChild(app);

--- a/deskmark/app/components/desk-mark/desk-mark.jsx
+++ b/deskmark/app/components/desk-mark/desk-mark.jsx
@@ -33,13 +33,13 @@ export default class App extends React.Component {
     this.setState({items: storage.getAll(), item: entry});
   }
   openEditor(item) {
-    this.setState({item: item });
+    this.setState({item: item});
   }
   openEmptyEditor() {
     let emptyEntry = {
       'title': '',
       'content': ''
-    }
+    };
     this.setState({item: emptyEntry});
   }
   cancelCreate() {
@@ -52,16 +52,16 @@ export default class App extends React.Component {
           <a className="navbar-brand" href="#">Deskmark App</a>
         </nav>
         <div className="container">
-            <div className="row">
-              <List items={this.state.items}
-                    onOpenEditor={this.openEditor}
-                    onOpenEmptyEditor={this.openEmptyEditor}/>
-              <Editor item={this.state.item}
-                      onDeleteItem={this.deleteItem}
-                      onSaveItem={this.saveItem}
-                      onCreateItem={this.createItem}
-                      onCancelCreate={this.cancelCreate}/>
-            </div>
+          <div className="row">
+            <List items={this.state.items}
+              onOpenEditor={this.openEditor}
+              onOpenEmptyEditor={this.openEmptyEditor}/>
+            <Editor item={this.state.item}
+              onDeleteItem={this.deleteItem}
+              onSaveItem={this.saveItem}
+              onCreateItem={this.createItem}
+              onCancelCreate={this.cancelCreate}/>
+          </div>
         </div>
       </section>
     );

--- a/deskmark/app/components/editor/editor.jsx
+++ b/deskmark/app/components/editor/editor.jsx
@@ -24,7 +24,7 @@ class Editor extends React.Component {
     if (!nextProps.item) {
       return;
     }
-    if (nextProps.item.title === '') {
+    if (!nextProps.item.id) {
       this.setState({editMode: true, createMode: true});
     } else {
       this.setState({editMode: false, createMode: false});

--- a/deskmark/app/components/editor/editor.jsx
+++ b/deskmark/app/components/editor/editor.jsx
@@ -62,9 +62,9 @@ class Editor extends React.Component {
     let createMode = this.state.createMode;
     let createOrEdit = null;
     if (createMode) {
-      createOrEdit = <button onClick={this.createItem} className="btn btn-success">创建</button>
+      createOrEdit = <button onClick={this.createItem} className="btn btn-success">创建</button>;
     } else {
-      createOrEdit = <button onClick={this.saveEdit} className="btn btn-success">保存</button>
+      createOrEdit = <button onClick={this.saveEdit} className="btn btn-success">保存</button>;
     }
     if (this.props.item) {
       if (editMode) {
@@ -77,11 +77,11 @@ class Editor extends React.Component {
             <div className="edit-area">
               <input ref="title" placeholder="请填写标题" defaultValue={this.props.item.title}/>
               <textarea ref="content"
-                        placeholder="请填写内容"
-                        defaultValue={this.props.item.content}/>
+                placeholder="请填写内容"
+                defaultValue={this.props.item.content}/>
             </div>
           </div>
-        )
+        );
       } else {
         let html = marked(this.props.item.content);
         return (
@@ -95,14 +95,14 @@ class Editor extends React.Component {
               <div dangerouslySetInnerHTML={{__html: html}} />
             </div>
           </div>
-        )
+        );
       }
     } else {
       return (
         <div className="col-md-8 editor-component">
           <div className="no-select">请选择左侧列表里面的文章</div>
         </div>
-      )
+      );
     }
   }
 }

--- a/deskmark/app/components/list/createBar.jsx
+++ b/deskmark/app/components/list/createBar.jsx
@@ -5,5 +5,5 @@ export default function CreateBar({onOpenEmptyEditor}){
     <a href="#" onClick={onOpenEmptyEditor} className="list-group-item create-entry">
       + 创建新的文章
     </a>
-  )
+  );
 }

--- a/deskmark/app/components/list/item.jsx
+++ b/deskmark/app/components/list/item.jsx
@@ -17,13 +17,13 @@ class Item extends React.Component {
     return (
       <a href="#"
         className="list-group-item item-component"
-        onClick={() => onOpenEditor(item) }>
+        onClick={() => onOpenEditor(item)}>
         <span className="label label-default label-pill pull-xs-right">
           {formatTime}
         </span>
         {item.title}
       </a>
-    )
+    );
   }
 }
 

--- a/deskmark/app/components/list/list.jsx
+++ b/deskmark/app/components/list/list.jsx
@@ -13,18 +13,20 @@ class List extends React.Component {
     super(props);
   }
   render() {
+    let items = this.props.items.map(item => {
+      return (
+        <Item item={item}
+          key={item.id}
+          onOpenEditor={this.props.onOpenEditor} />
+      );
+    });
+
     return (
       <div className="list-component col-md-4 list-group">
         <CreateBar onOpenEmptyEditor={this.props.onOpenEmptyEditor}/ >
-        {
-          this.props.items.map(function(item) {
-            return <Item item={item}
-                      key={item.id}
-                      onOpenEditor={this.props.onOpenEditor} />
-          }.bind(this))
-        }
+        {items}
       </div>
-    )
+    );
   }
 }
 

--- a/deskmark/app/utils/storage.js
+++ b/deskmark/app/utils/storage.js
@@ -9,19 +9,20 @@ let storage = {
       return [];
     }
   },
+  saveAll(results) {
+    window.localStorage.setItem('deskmark', JSON.stringify(results));
+  },
   getEntry(id) {
     let results = this.getAll();
-    let entry = results.find(function(result) {
-      return result.id === id;
-    });
+    let entry = results.find(result => result.id === id);
     return entry;
   },
   insertEntry(title, content) {
     let results = this.getAll();
     let id = uuid.v4();
-    let entry = {'id': id, 'title': title, 'content': content, 'time': new Date().getTime()};
+    let entry = {id, title, content, 'time': new Date().getTime()};
     results.push(entry);
-    window.localStorage.setItem('deskmark', JSON.stringify(results));
+    this.saveAll(results);
     return entry;
   },
   deleteEntry(id) {
@@ -29,7 +30,7 @@ let storage = {
     let index = results.map(function(entry) {return entry.id}).indexOf(id);
     if (index != -1) {
       results.splice(index, 1);
-      window.localStorage.setItem('deskmark', JSON.stringify(results));
+      this.saveAll(results);
     }
   },
   updateEntry(id, title, content) {
@@ -39,7 +40,7 @@ let storage = {
     });
     entry.title = title;
     entry.content = content;
-    window.localStorage.setItem('deskmark', JSON.stringify(results));
+    this.saveAll(results);
   }
 }
 

--- a/deskmark/app/utils/storage.js
+++ b/deskmark/app/utils/storage.js
@@ -11,7 +11,7 @@ let storage = {
   },
   getEntry(id) {
     let results = this.getAll();
-    let entry =  results.find(function(result) {
+    let entry = results.find(function(result) {
       return result.id === id;
     });
     return entry;

--- a/deskmark/webpack.config.js
+++ b/deskmark/webpack.config.js
@@ -27,11 +27,7 @@ module.exports= {
   },
   resolve: {
     extensions: ['', '.js', '.jsx'],
-    alias: {
-      'node_modules': path.resolve(ROOT_PATH, 'node_modules/'),
-      'utils': path.resolve(APP_PATH, 'utils/'),
-      'components': path.resolve(APP_PATH, 'components/')
-    }
+    root: APP_PATH
   },
   module: {
     loaders: [


### PR DESCRIPTION
- webpack resolve 配置（webpack.config.js & app.jsx）
  
  考虑到目前的 alias 配置中 utils 及 components 都在 deskmark 目录下，直接使用 resolve.root 进行配置更为简单清楚。另外，感觉 node_modules 没有配置为 alias 的必要，`require('node_modules/xxx')` 的地方直接 `require('xxx')` 更合理一点。
- editor 的一个 debug：
  
  通过 item.id，而不是 item.title 来判断当前是否为 createMode，使用后者的话，在修改 title 为空的 item 时存在 bug
- typo
  
  缩进以及句末分号的统一
- storage.js
  
  把保存数组的公共逻辑抽象到 saveAll 中
